### PR TITLE
IDFV for uniqueness

### DIFF
--- a/Sources/SimpleAnalytics/SimpleAnalytics.swift
+++ b/Sources/SimpleAnalytics/SimpleAnalytics.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// SimpleAnalytics allows you to send events and pageviews from Swift  to Simple Analytics
 ///


### PR DESCRIPTION
This uses https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor for uniqueness instead of the visit date. This data is never sent anywhere outside the device.