### PR TITLE
feature/app-group-storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ SimpleAnalytics.shared.track(event: "logged in", path: ["login", "social"])
 ```
 
 ### Tracking Visitors for Apps + Widgets
-If you have an app + widget(s), by default, these are treated as separate 'visitors'. However, you can prevent one visitor from appearing multiple times by creating an App Group in your Xcode project in each of your targets (Project > Targets > Signing & Capabilities > App Groups) with the same name. Use this app group name in your SimpleAnalytics instance.
+If you have an app + widget(s), by default one visit per day per target (app, widget) is treated as separate 'visitors'. This means that if you have an app with a small and medium widget, one person using all three will show in your SimpleAnalytics dashboard as 3 visitors. However, you can ensure one visitor only appears once per day by creating an App Group in your Xcode project. Create a new App Group ([instructions](https://developer.apple.com/documentation/xcode/configuring-app-groups)) in each of your targets (Project > Targets > Signing & Capabilities > App Groups) with the same name. Use this app group name in your SimpleAnalytics instance.
 ```swift
-let simpleAnalytics = SimpleAnalytics(hostname: "app.simpleanalytics.com", sharedDefaultsSuiteName: "com.simpleanlytics.app")
+let simpleAnalytics = SimpleAnalytics(hostname: "app.simpleanalytics.com", sharedDefaultsSuiteName: "group.com.simpleanlytics.app")
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ You can provide an optional path to track alongside the event.
 SimpleAnalytics.shared.track(event: "logged in", path: ["login", "social"])
 ```
 
+### Tracking Visitors for Apps + Widgets
+If you have an app + widget(s), by default, these are treated as separate 'visitors'. However, you can prevent one visitor from appearing multiple times by creating an App Group in your Xcode project in each of your targets (Project > Targets > Signing & Capabilities > App Groups) with the same name. Use this app group name in your SimpleAnalytics instance.
+```swift
+let simpleAnalytics = SimpleAnalytics(hostname: "app.simpleanalytics.com", sharedDefaultsSuiteName: "com.simpleanlytics.app")
+```
+
 ## Examples
 ### SwiftUI example
  In SwiftUI, a good place to put the Pageview tracking code is in your view `.onAppear{}` modifier. 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ SimpleAnalytics.shared.track(event: "logged in", path: ["login", "social"])
 ```
 
 ### Tracking Visitors for Apps + Widgets
-If you have an app + widget(s), by default one visit per day per target (app, widget) is treated as separate 'visitors'. This means that if you have an app with a small and medium widget, one person using all three will show in your SimpleAnalytics dashboard as 3 visitors. However, you can ensure one visitor only appears once per day by creating an App Group in your Xcode project. Create a new App Group ([instructions](https://developer.apple.com/documentation/xcode/configuring-app-groups)) in each of your targets (Project > Targets > Signing & Capabilities > App Groups) with the same name. Use this app group name in your SimpleAnalytics instance.
+If you have an app + widget(s), by default one visit per day per target (app, widget) is treated as separate 'visitors'. This means that if you have an app with a small and medium widget, one person using the core app and both widgets will show in your SimpleAnalytics dashboard as 3 visitors. However, you can ensure one visitor only appears once per day by creating an App Group in your Xcode project. Create a new App Group ([instructions](https://developer.apple.com/documentation/xcode/configuring-app-groups)) in each of your targets (Project > Targets > Signing & Capabilities > App Groups) with the same name. Use this app group name in your SimpleAnalytics instance.
 ```swift
 let simpleAnalytics = SimpleAnalytics(hostname: "app.simpleanalytics.com", sharedDefaultsSuiteName: "group.com.simpleanlytics.app")
 ```

--- a/Tests/SimpleAnalyticsTests/Swift_SimpleAnalyticsTests.swift
+++ b/Tests/SimpleAnalyticsTests/Swift_SimpleAnalyticsTests.swift
@@ -48,6 +48,24 @@ final class Swift_SimpleAnalyticsTests: XCTestCase {
 
     }
     
+    func testPageviewWithDefaultsGroup() throws {
+        let expectation = XCTestExpectation(description: "Log a pageview")
+
+        let tracker = SimpleAnalytics(hostname: "simpleanalyticsswift.app", sharedDefaultsSuiteName: "app.yourapp.com")
+        tracker.trackPageView(path: "/test")
+        wait(for: [expectation], timeout: 10.0)
+
+    }
+    
+    func testEventWithDefaultsGroup() throws {
+        let expectation = XCTestExpectation(description: "Log a pageview")
+
+        let tracker = SimpleAnalytics(hostname: "simpleanalyticsswift.app", sharedDefaultsSuiteName: "app.yourapp.com")
+        tracker.trackEvent(event: "test")
+        wait(for: [expectation], timeout: 10.0)
+
+    }
+    
     func testPath() {
         
         let tracker = SimpleAnalytics(hostname: "simpleanalyticsswift.app")


### PR DESCRIPTION
Hi again.

I found I needed this because I'm using this in an app + widgets so that users weren't double-counted in my visits -- wanted to share. the standard UserDefaults isn't shared between apps and widget extensions, so this is needed to maintain those visitDates between them all.

Enjoy, hope this helps